### PR TITLE
Add vault metadata registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Folder overview:
 - `src` - main protocol contracts and libraries.
 - `contracts` - additional extension contracts used for examples or integrations.
 - `contracts/vaults/ComposableVaultFactory.sol` - deployer for creating `ComposableVault` instances.
+- `contracts/VaultRegistry.sol` - registry storing vault metadata for UIs and indexers.
 - `docs` - documentation files including architecture diagrams and audit reports.
 - `env` - helper scripts and environment configuration for tests.
 - `lib` - external libraries installed via Forge.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Vault factories deploy vault implementations with the correct permissions.
 - **SyncDepositVaultFactory** - creates `SyncDepositVault` contracts.
 - **ComposableVaultFactory** - creates `ComposableVault` instances.
 
+## Metadata Registry
+
+`VaultRegistry` stores metadata for deployed vaults. Authorized factories or admins call `registerVault` after deployment to record a human readable name, description, metadata URI, factory and creator addresses, vault type and timestamp. UIs and indexers can list all vaults via `getVaults()` and fetch individual metadata with `getMetadata(vault)`.
+
 
 ## Contributing
 #### Getting started

--- a/contracts/VaultRegistry.sol
+++ b/contracts/VaultRegistry.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Auth} from "../src/misc/Auth.sol";
+
+/// @title  Vault Registry
+/// @notice Tracks deployed vaults and their metadata.
+contract VaultRegistry is Auth {
+    struct Metadata {
+        string name;
+        string description;
+        string metadataURI;
+        string vaultType;
+        address creator;
+        address factory;
+        uint64 timestamp;
+    }
+
+    /// @notice Emitted when a vault is registered.
+    event VaultRegistered(address indexed vault, address indexed factory, address indexed creator, string vaultType);
+
+    /// @dev List of all registered vaults.
+    address[] public vaults;
+
+    /// @dev Metadata stored for each vault.
+    mapping(address => Metadata) internal _metadata;
+
+    constructor(address deployer) Auth(deployer) {}
+
+    /// @notice Register a new vault and store its metadata.
+    function registerVault(
+        address vault,
+        string calldata name,
+        string calldata description,
+        string calldata metadataURI,
+        string calldata vaultType,
+        address creator,
+        address factory
+    ) external auth {
+        require(_metadata[vault].timestamp == 0, "already registered");
+
+        _metadata[vault] = Metadata({
+            name: name,
+            description: description,
+            metadataURI: metadataURI,
+            vaultType: vaultType,
+            creator: creator,
+            factory: factory,
+            timestamp: uint64(block.timestamp)
+        });
+
+        vaults.push(vault);
+        emit VaultRegistered(vault, factory, creator, vaultType);
+    }
+
+    /// @notice Returns the list of all registered vault addresses.
+    function getVaults() external view returns (address[] memory) {
+        return vaults;
+    }
+
+    /// @notice Returns the metadata for a vault.
+    function getMetadata(address vault) external view returns (Metadata memory) {
+        return _metadata[vault];
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `VaultRegistry` contract for vault metadata
- document registry usage in README
- mention new registry in AGENTS overview

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_686bb040e80883288f98dbae0e724579