### PR TITLE
Add vault composition support to SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Folder overview:
 - `scripts` - offchain monitoring and indexer scripts.
 - `snapshots` - test snapshots used by Forge.
 - `test` - all unit, integration and fuzz tests for the protocol.
-- `vault-sdk` - TypeScript SDK for querying vault metadata and drift metrics.
+- `vault-sdk` - TypeScript SDK for querying vault metadata, vault composition (see `vault-sdk/src/composition.ts`) and drift metrics.
 
 Root files:
 - `foundry.toml` - Forge configuration.

--- a/vault-sdk/README.md
+++ b/vault-sdk/README.md
@@ -20,4 +20,11 @@ const vaults = await sdk.listVaults()
 console.log(vaults)
 ```
 
-`listVaults()` returns the metadata stored in `VaultRegistry` for all registered vaults. Additional methods will be added in future updates.
+`listVaults()` returns the metadata stored in `VaultRegistry` for all registered vaults.
+
+```ts
+const composition = await sdk.getComposition('0xVault', '0xHoldings')
+console.log(composition)
+```
+
+`getComposition()` aggregates vault asset configs with live values from `IHoldings` to calculate the current weights.

--- a/vault-sdk/src/VaultSDK.ts
+++ b/vault-sdk/src/VaultSDK.ts
@@ -1,5 +1,6 @@
-import { VaultMetadata } from './types'
+import { VaultMetadata, VaultComposition } from './types'
 import { getAllVaults, getVaultMetadata } from './registry'
+import { fetchVaultComposition } from './composition'
 
 export class VaultSDK {
   provider: any
@@ -14,6 +15,10 @@ export class VaultSDK {
     const vaults = await getAllVaults(this.provider, this.registry)
     const meta = await Promise.all(vaults.map(v => getVaultMetadata(this.provider, this.registry, v)))
     return meta
+  }
+
+  async getComposition(vaultAddr: string, holdingsAddr: string): Promise<VaultComposition[]> {
+    return await fetchVaultComposition(this.provider, vaultAddr, holdingsAddr)
   }
 
   // More methods coming in future prompts...

--- a/vault-sdk/src/composition.ts
+++ b/vault-sdk/src/composition.ts
@@ -1,0 +1,47 @@
+import { ethers, BigNumber } from 'ethers'
+import { VaultComposition } from './types'
+
+const VAULT_ABI = [
+  'function assetsLength() view returns (uint256)',
+  'function assetConfigs(uint256) view returns (uint128 assetId,address asset,uint16 targetWeightBps)',
+  'function poolId() view returns (uint256)',
+  'function scId() view returns (uint256)'
+]
+
+const HOLDINGS_ABI = [
+  'function value(uint256 poolId,uint256 scId,uint256 assetId) view returns (uint128)'
+]
+
+export async function fetchVaultComposition(provider: any, vaultAddr: string, holdingsAddr: string): Promise<VaultComposition[]> {
+  const vault = new ethers.Contract(vaultAddr, VAULT_ABI, provider)
+  const holdings = new ethers.Contract(holdingsAddr, HOLDINGS_ABI, provider)
+
+  const len: number = await vault.assetsLength()
+  const poolId: BigNumber = await vault.poolId()
+  const scId: BigNumber = await vault.scId()
+
+  const configs = [] as VaultComposition[]
+  const values: BigNumber[] = []
+
+  for (let i = 0; i < len; i++) {
+    const cfg = await vault.assetConfigs(i)
+    const value: BigNumber = await holdings.value(poolId, scId, cfg.assetId)
+    values.push(value)
+    configs.push({
+      asset: cfg.asset,
+      assetId: cfg.assetId.toString(),
+      value: value.toString(),
+      targetBps: Number(cfg.targetWeightBps),
+      actualBps: 0
+    })
+  }
+
+  const total = values.reduce((acc, v) => acc.add(v), BigNumber.from(0))
+  if (!total.isZero()) {
+    configs.forEach((c, idx) => {
+      c.actualBps = Number(values[idx].mul(10000).div(total))
+    })
+  }
+
+  return configs
+}

--- a/vault-sdk/src/types.ts
+++ b/vault-sdk/src/types.ts
@@ -17,3 +17,11 @@ export interface DriftEvent {
   actualBps: number
   driftBps: number
 }
+
+export interface VaultComposition {
+  asset: string
+  assetId: string
+  value: string
+  targetBps: number
+  actualBps: number
+}


### PR DESCRIPTION
## Summary
- extend Vault SDK with getComposition helper
- compute per-asset weights from IHoldings values
- document new SDK method in README
- mention composition helper in AGENTS overview

## Testing
- `npx -y ts-node vault-sdk/test/sdk.test.ts`
- `forge --version`
- `forge test` *(fails: compiling dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bbae296c48328ba07a540ead277e5