### PR TITLE
Add redemption queue stats and share price indexer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,12 @@ Folder overview:
 - `docs` - documentation files including architecture diagrams and audit reports.
 - `env` - helper scripts and environment configuration for tests.
 - `lib` - external libraries installed via Forge.
-- `scripts` - offchain monitoring and indexer scripts.
+- `scripts` - offchain monitoring and indexer scripts (see `scripts/README.md`).
+  - `SharePriceIndexer.ts` builds share price history in `logs/share_price.csv`.
 - `snapshots` - test snapshots used by Forge.
 - `test` - all unit, integration and fuzz tests for the protocol.
-- `vault-sdk` - TypeScript SDK for querying vault metadata, vault composition (see `vault-sdk/src/composition.ts`) and drift metrics.
+- `vault-sdk` - TypeScript SDK for querying vault metadata, vault composition, drift metrics and redemption queues.
+  - Redemption queue logic is implemented in `vault-sdk/src/VaultSDK.ts`.
 
 Root files:
 - `foundry.toml` - Forge configuration.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Centrifuge V3 operates on a hub-and-spoke model. Each pool chooses a single hub 
   - `vaults` extension of Centrifuge Spoke, for ERC-4626 and ERC-7540 vaults
   - `hooks` extension of Centrifuge Spoke, for implementing transfer hooks
 - `test` cotains all tests: unitary test, integration test per module, and end-to-end integration tests
-- `vault-sdk` early TypeScript SDK for querying vault metadata and drift metrics
+- `vault-sdk` early TypeScript SDK for querying vault metadata, drift metrics and redemption queues. Use `getRedemptionQueue(vault)` to retrieve pending and claimable redeem totals.
 
 ## Vault Types
 
@@ -109,8 +109,9 @@ forge test
 | [Macro](https://0xmacro.com/)                      | V3.0        | May 2025        | Security review            | [`Report`](https://0xmacro.com/library/audits/centrifuge-1.html)                                                                             |
 
 ## Monitoring & Tooling
-- `scripts/VaultDriftIndexer.ts` - indexer for `DriftExceeded` events, see [scripts/README.md](scripts/README.md).
-- `vault-sdk` - TypeScript SDK for reading vault metadata and drift metrics.
+ - `scripts/VaultDriftIndexer.ts` - indexer for `DriftExceeded` events, see [scripts/README.md](scripts/README.md).
+ - `scripts/SharePriceIndexer.ts` - dumps share price updates to `logs/share_price.csv`.
+ - `vault-sdk` - TypeScript SDK for reading vault metadata, drift metrics and redemption queues.
 
 ## License
 The primary license is the [Business Source License 1.1](https://github.com/centrifuge/protocol-v3/blob/main/LICENSE). However, all files in the [`src/misc`](./src/misc) folder, [`src/managers/MerkleProofManager.sol`](./src/managers/MerkleProofManager.sol), and any interface file can also be licensed under `GPL-2.0-or-later` (as indicated in their SPDX headers).

--- a/scripts/SharePriceIndexer.ts
+++ b/scripts/SharePriceIndexer.ts
@@ -1,0 +1,46 @@
+import { config as loadEnv } from 'dotenv'
+import { ethers } from 'ethers'
+import fs from 'fs'
+import path from 'path'
+
+loadEnv()
+
+const RPC_URL = process.env.RPC_URL
+if (!RPC_URL) {
+  console.error('RPC_URL environment variable not set')
+  process.exit(1)
+}
+
+const provider = new ethers.providers.JsonRpcProvider(RPC_URL)
+
+// Address of the Hub or Spoke contract emitting UpdateSharePrice
+const HUB_ADDRESS = '0xHubAddress'
+
+const SHARE_PRICE_ABI = [
+  'event UpdateSharePrice(uint256 indexed poolId,uint256 indexed scId,uint256 price,uint64 computedAt)'
+]
+
+async function main() {
+  const hub = new ethers.Contract(HUB_ADDRESS, SHARE_PRICE_ABI, provider)
+  const filter = hub.filters.UpdateSharePrice()
+  const events = await hub.queryFilter(filter, 0, 'latest')
+
+  const csvPath = path.join(__dirname, '..', 'logs', 'share_price.csv')
+  fs.mkdirSync(path.dirname(csvPath), { recursive: true })
+  if (!fs.existsSync(csvPath)) {
+    fs.writeFileSync(csvPath, 'timestamp,vault,price\n')
+  }
+
+  for (const ev of events) {
+    const block = await provider.getBlock(ev.blockNumber)
+    const vault = `${ev.args.poolId.toString()}-${ev.args.scId.toString()}`
+    const line = `${block.timestamp},${vault},${ev.args.price.toString()}\n`
+    fs.appendFileSync(csvPath, line)
+    console.log(`Share price | vault: ${vault} price: ${ev.args.price.toString()} | ${new Date(block.timestamp * 1000).toISOString()}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/vault-sdk/README.md
+++ b/vault-sdk/README.md
@@ -28,3 +28,10 @@ console.log(composition)
 ```
 
 `getComposition()` aggregates vault asset configs with live values from `IHoldings` to calculate the current weights.
+
+```ts
+const queue = await sdk.getRedemptionQueue('0xVault')
+console.log(queue)
+```
+
+`getRedemptionQueue()` sums pending and claimable redeem requests for the vault and can optionally take a user address as second parameter.

--- a/vault-sdk/src/VaultSDK.ts
+++ b/vault-sdk/src/VaultSDK.ts
@@ -1,6 +1,7 @@
-import { VaultMetadata, VaultComposition } from './types'
+import { VaultMetadata, VaultComposition, RedemptionQueue } from './types'
 import { getAllVaults, getVaultMetadata } from './registry'
 import { fetchVaultComposition } from './composition'
+import { ethers, BigNumber } from 'ethers'
 
 export class VaultSDK {
   provider: any
@@ -19,6 +20,54 @@ export class VaultSDK {
 
   async getComposition(vaultAddr: string, holdingsAddr: string): Promise<VaultComposition[]> {
     return await fetchVaultComposition(this.provider, vaultAddr, holdingsAddr)
+  }
+
+  async getRedemptionQueue(vaultAddr: string, user?: string): Promise<RedemptionQueue> {
+    const VAULT_ABI = ['function asyncManager() view returns (address)']
+    const MANAGER_ABI = [
+      'function pendingRedeemRequest(address,address) view returns (uint256)',
+      'function claimableCancelRedeemRequest(address,address) view returns (uint256)'
+    ]
+    const EVENT_ABI = [
+      'event RedeemRequest(address indexed controller,address indexed owner,uint256 indexed requestId,address sender,uint256 shares)'
+    ]
+
+    const vault = new ethers.Contract(vaultAddr, VAULT_ABI, this.provider)
+    const managerAddr: string = await vault.asyncManager()
+    const manager = new ethers.Contract(managerAddr, MANAGER_ABI, this.provider)
+
+    if (user) {
+      const pending: BigNumber = await manager.pendingRedeemRequest(vaultAddr, user)
+      const claimable: BigNumber = await manager.claimableCancelRedeemRequest(vaultAddr, user)
+      const size = !pending.isZero() || !claimable.isZero() ? 1 : 0
+      return { queueSize: size, pendingAmount: pending.toString(), claimableAmount: claimable.toString() }
+    }
+
+    const vaultEvents = new ethers.Contract(vaultAddr, EVENT_ABI, this.provider)
+    const events = await vaultEvents.queryFilter(vaultEvents.filters.RedeemRequest(), 0, 'latest')
+    const controllers = new Set<string>()
+    events.forEach((ev: any) => {
+      controllers.add(ev.args.controller.toLowerCase())
+    })
+
+    let pendingTotal = BigNumber.from(0)
+    let claimableTotal = BigNumber.from(0)
+    let count = 0
+    for (const addr of controllers) {
+      const pending: BigNumber = await manager.pendingRedeemRequest(vaultAddr, addr)
+      const claimable: BigNumber = await manager.claimableCancelRedeemRequest(vaultAddr, addr)
+      if (!pending.isZero() || !claimable.isZero()) {
+        count++
+        pendingTotal = pendingTotal.add(pending)
+        claimableTotal = claimableTotal.add(claimable)
+      }
+    }
+
+    return {
+      queueSize: count,
+      pendingAmount: pendingTotal.toString(),
+      claimableAmount: claimableTotal.toString()
+    }
   }
 
   // More methods coming in future prompts...

--- a/vault-sdk/src/types.ts
+++ b/vault-sdk/src/types.ts
@@ -25,3 +25,15 @@ export interface VaultComposition {
   targetBps: number
   actualBps: number
 }
+
+export interface RedemptionQueue {
+  queueSize: number
+  pendingAmount: string
+  claimableAmount: string
+}
+
+export interface SharePriceRecord {
+  timestamp: number
+  vault: string
+  price: string
+}


### PR DESCRIPTION
## Summary
- expose `RedemptionQueue` and `SharePriceRecord` types
- implement `getRedemptionQueue` in VaultSDK
- add script `SharePriceIndexer.ts` for share price history
- document new SDK capabilities and tooling
- update AGENTS instructions

## Testing
- `npx tsc -p vault-sdk/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686bbe102ec08328ae43feb8ff5decb2